### PR TITLE
Update to 22w14a (1.19)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.1
+minecraft_version=22w14a
+yarn_mappings=22w14a+build.12
 loader_version=0.13.3
-fabric_version=0.47.8+1.18.2
+fabric_version=0.49.0+1.19
 
 # Mod Properties
 mod_version=0.4.1
 maven_group=me.jellysquid.mods
-archives_base_name=sodium-fabric
+archives_base_name=sodium-fabric-forked-1.19


### PR DESCRIPTION
Supports 22w14a or later snapshots.

Unsupported Snapshots
22w11a, 22w12a & 22w13a